### PR TITLE
Add travis testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,16 +5,8 @@
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 
 ignore =
-    # E203: whitespace before ':'
-    E203,
-    # E226: missing whitespace around arithmetic operator
-    E226,
-    # E231: missing whitespace after ',', ';', or ':'
-    E231,
-    # E402: module level imports on one line
+    # E402: module level imports at top of file
     E402,
-    # E501: line too long
-    E501,
     # W503: line break before binary operator
     W503,
     # W504: line break after binary operator
@@ -25,16 +17,3 @@ exclude =
     #
     .eggs,
     build,
-    compiled_krb,
-    docs/iris/src/sphinxext/*,
-    tools/*,
-    #
-    # ignore auto-generated files
-    #
-    _ff_cross_refrences.py,
-    std_names.py,
-    um_cf_map.py,
-    #
-    # ignore third-party files
-    #
-    gitwash_dumper.py,

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,40 @@
+[flake8]
+# References:
+#   https://flake8.readthedocs.io/en/latest/user/configuration.html
+#   https://flake8.readthedocs.io/en/latest/user/error-codes.html
+#   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+
+ignore =
+    # E203: whitespace before ':'
+    E203,
+    # E226: missing whitespace around arithmetic operator
+    E226,
+    # E231: missing whitespace after ',', ';', or ':'
+    E231,
+    # E402: module level imports on one line
+    E402,
+    # E501: line too long
+    E501,
+    # W503: line break before binary operator
+    W503,
+    # W504: line break after binary operator
+    W504,
+exclude =
+    #
+    # ignore the following directories
+    #
+    .eggs,
+    build,
+    compiled_krb,
+    docs/iris/src/sphinxext/*,
+    tools/*,
+    #
+    # ignore auto-generated files
+    #
+    _ff_cross_refrences.py,
+    std_names.py,
+    um_cf_map.py,
+    #
+    # ignore third-party files
+    #
+    gitwash_dumper.py,

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,4 @@
+linters:
+    flake8:
+        python: 3
+        config: ./.flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
     - PYTHON_VERSION=3.7
 
 install:
+  # capture installation dir
+  - export INSTALL_DIR=${pwd}
 
   # iris test-data reference is just a commit
   - export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07";
@@ -82,12 +84,14 @@ install:
 
   # Finally, install iris-ugrid itself.
   # FOR NOW : just put it on the module searchpath (no actual install code)
+  - cd ..;
   - export PYTHONPATH=$(readlink -f .):$PYTHONPATH;
 
 
 script:
 
   - >
+    echo "Testing : recall install dir = ${INSTALL_DIR}";
     echo "Tests running from : $(pwd)";
     echo "Testing : initial PYTHONPATH=${PYTHONPATH}";
     export PYTHONPATH=$(pwd):${PYTHONPATH};

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ install:
   - export INSTALL_DIR=${pwd}
 
   # iris test-data reference is just a commit
-  - export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07";
+  - export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07"
 
   # iris reference is to the latest "ng-vat_v2" branch
-  - export IRIS_BRANCH="ng-vat_v2";
+  - export IRIS_BRANCH="ng-vat_v2"
 
   # download and install iris test data
   - >
@@ -90,10 +90,4 @@ install:
 
 script:
 
-  - >
-    echo "Testing : recall install dir = ${INSTALL_DIR}";
-    echo "Tests running from : $(pwd)";
-    echo "Testing : initial PYTHONPATH=${PYTHONPATH}";
-    export PYTHONPATH=$(pwd):${PYTHONPATH};
-    echo "Testing : adjusted PYTHONPATH=${PYTHONPATH}";
-    python -m unittest discover -v ./iris_ugrid/tests;
+  - python -m unittest discover -v ./iris_ugrid/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,15 +70,15 @@ install:
     echo "[System]" >> ${SITE_CFG};
     echo "udunits2_path = ${PREFIX}/lib/libudunits2.so" >> ${SITE_CFG};
 
-  # install iris itself
-  - >
-    cd iris;
-    python setup.py --quiet install;
-
   # Output environment debug info
   - >
     conda list -n ${ENV_NAME};
     conda info -a;
+
+  # install iris itself
+  - >
+    cd iris;
+    pip install -e .python setup.py --quiet install;
 
   # Finally, install iris-ugrid itself.
   # FOR NOW : just put it on the module searchpath (no actual install code)
@@ -87,5 +87,9 @@ install:
 
 script:
 
-  - python -m unittest discover -v ./iris_ugrid/tests
-
+  - >
+    echo "Testing : initial PYTHONPATH=${PYTHONPATH}";
+    echo "Tests running from : $(pwd)";
+    export PYTHONPATH=$(readlink -f .):${PYTHONPATH};
+    echo "Testing : adjusted PYTHONPATH=${PYTHONPATH}";
+    python -m unittest discover -v ./iris_ugrid/tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,10 @@ install:
     conda list -n ${ENV_NAME};
     conda info -a;
 
-  # install iris itself
+  # install iris
   - >
     cd iris;
-    pip install -e .;
+    python setup.py --quiet install;
 
   # Finally, install iris-ugrid itself.
   # FOR NOW : just put it on the module searchpath (no actual install code)

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,12 @@ install:
     conda install --quiet -n ${ENV_NAME} --file ${CONDA_REQS_FILE};
 
   # Conda-install our own additional dependencies.
-  - conda install gridded
+  - conda install --file conda_requirements.txt
+
+  # Output environment debug info
+  - >
+    conda list -n ${ENV_NAME};
+    conda info -a;
 
   # set iris config paths
   - >
@@ -71,11 +76,6 @@ install:
     echo "doc_dir = $(pwd)/docs/iris" >> ${SITE_CFG};
     echo "[System]" >> ${SITE_CFG};
     echo "udunits2_path = ${PREFIX}/lib/libudunits2.so" >> ${SITE_CFG};
-
-  # Output environment debug info
-  - >
-    conda list -n ${ENV_NAME};
-    conda info -a;
 
   # install iris
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,88 @@
+language: minimal
+dist: xenial
+
+install:
+
+  # iris test-data reference is just a commit
+  export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07";
+
+  # iris reference is to the latest "ng-vat_v2" branch
+  export IRIS_BRANCH="ng-vat_v2";
+
+  # download and install iris test data
+  - >
+    if [[ "${TEST_MINIMAL}" != true ]]; then
+      wget --quiet -O iris-test-data.zip https://github.com/SciTools/iris-test-data/archive/${IRIS_TEST_DATA_REF}.zip;
+      unzip -q iris-test-data.zip;
+      mv "iris-test-data-${IRIS_TEST_DATA_REF}" iris-test-data;
+    fi
+
+  # download iris branch
+  - >
+    wget --quiet -O iris.zip wget https://github.com/SciTools/iris/archive/${IRIS_BRANCH}.zip
+    unzip -q iris.zip;
+    mv "iris-${IRIS_BRANCH}" iris;
+
+  # install miniconda
+  - >
+    echo 'Installing miniconda';
+    export CONDA_BASE="https://repo.continuum.io/miniconda/Miniconda";
+    wget --quiet ${CONDA_BASE}3-latest-Linux-x86_64.sh -O miniconda.sh;
+    bash miniconda.sh -b -p ${HOME}/miniconda;
+    export PATH="${HOME}/miniconda/bin:${PATH}";
+
+  # Create the testing conda environment
+  # ------------------------------------
+  # Explicitly add defaults channel, see https://github.com/conda/conda/issues/2675
+  - >
+    echo 'Configure conda and create an environment';
+    conda config --set always_yes yes --set changeps1 no;
+    conda config --set show_channel_urls True;
+    conda config --add channels conda-forge;
+    conda update --quiet conda;
+    export ENV_NAME='test-environment';
+    conda create --quiet -n ${ENV_NAME} python=${PYTHON_VERSION} pip;
+    source activate ${ENV_NAME};
+
+  # Install iris dependencies via conda, using iris/gen_conda_requirements.py
+  # -------------------------------------------------------------------------
+  - >
+    echo 'Install Iris + its test dependencies';
+    CONDA_REQS_GROUPS="test";
+    CONDA_REQS_FILE="conda-requirements.txt";
+    python iris/requirements/gen_conda_requirements.py --groups ${CONDA_REQS_GROUPS} > ${CONDA_REQS_FILE};
+    conda install --quiet -n ${ENV_NAME} --file ${CONDA_REQS_FILE};
+
+  # Conda-install our own additional dependencies.
+  - >
+    conda install gridded
+
+  # set iris config paths
+  - >
+    export PREFIX="${HOME}/miniconda/envs/${ENV_NAME}";
+    SITE_CFG="iris/lib/iris/etc/site.cfg";
+    echo "[Resources]" > ${SITE_CFG};
+    echo "test_data_dir = $(pwd)/iris-test-data/test_data" >> ${SITE_CFG};
+    echo "doc_dir = $(pwd)/docs/iris" >> ${SITE_CFG};
+    echo "[System]" >> ${SITE_CFG};
+    echo "udunits2_path = ${PREFIX}/lib/libudunits2.so" >> ${SITE_CFG};
+
+  # install iris itself
+  - >
+    cd iris;
+    python setup.py --quiet install;
+
+  # Output environment debug info
+  - >
+    conda list -n ${ENV_NAME};
+    conda info -a;
+
+  # Finally, install iris-ugrid itself.
+  # FOR NOW : just put it on the module searchpath (no actual install code)
+  - export PYTHONPATH=$(readlink -f .):$PYTHONPATH
+
+
+script:
+
+  - python -m unittest discover -v ./iris_ugrid/tests
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ dist: xenial
 install:
 
   # iris test-data reference is just a commit
-  export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07";
+  - export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07";
 
   # iris reference is to the latest "ng-vat_v2" branch
-  export IRIS_BRANCH="ng-vat_v2";
+  - export IRIS_BRANCH="ng-vat_v2";
 
   # download and install iris test data
   - >
@@ -19,7 +19,7 @@ install:
 
   # download iris branch
   - >
-    wget --quiet -O iris.zip wget https://github.com/SciTools/iris/archive/${IRIS_BRANCH}.zip
+    wget --quiet -O iris.zip wget https://github.com/SciTools/iris/archive/${IRIS_BRANCH}.zip;
     unzip -q iris.zip;
     mv "iris-${IRIS_BRANCH}" iris;
 
@@ -54,8 +54,7 @@ install:
     conda install --quiet -n ${ENV_NAME} --file ${CONDA_REQS_FILE};
 
   # Conda-install our own additional dependencies.
-  - >
-    conda install gridded
+  - conda install gridded
 
   # set iris config paths
   - >
@@ -79,7 +78,7 @@ install:
 
   # Finally, install iris-ugrid itself.
   # FOR NOW : just put it on the module searchpath (no actual install code)
-  - export PYTHONPATH=$(readlink -f .):$PYTHONPATH
+  - export PYTHONPATH=$(readlink -f .):$PYTHONPATH;
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: minimal
 dist: xenial
 
+env:
+  matrix:
+    - PYTHON_VERSION=3.7
+
 install:
 
   # iris test-data reference is just a commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
   # install iris itself
   - >
     cd iris;
-    pip install -e .python setup.py --quiet install;
+    pip install -e .;
 
   # Finally, install iris-ugrid itself.
   # FOR NOW : just put it on the module searchpath (no actual install code)
@@ -88,8 +88,8 @@ install:
 script:
 
   - >
-    echo "Testing : initial PYTHONPATH=${PYTHONPATH}";
     echo "Tests running from : $(pwd)";
-    export PYTHONPATH=$(readlink -f .):${PYTHONPATH};
+    echo "Testing : initial PYTHONPATH=${PYTHONPATH}";
+    export PYTHONPATH=$(pwd):${PYTHONPATH};
     echo "Testing : adjusted PYTHONPATH=${PYTHONPATH}";
     python -m unittest discover -v ./iris_ugrid/tests;

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,0 +1,1 @@
+gridded

--- a/iris_ugrid/__init__.py
+++ b/iris_ugrid/__init__.py
@@ -3,4 +3,4 @@
 # This file is part of Iris and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
-"""Top level of iris-ugrid package."""
+"""All tests for the :mod:`iris-ugrid` package."""

--- a/iris_ugrid/tests/__init__.py
+++ b/iris_ugrid/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Iris-ugrid contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""All tests for the :mod:`iris-ugrid` package."""

--- a/iris_ugrid/tests/test_install.py
+++ b/iris_ugrid/tests/test_install.py
@@ -9,9 +9,9 @@ Test that the correct iris is installed, including iris-ugrid support.
 TODO: remove this when we have other more sensible tests.
 
 """
-
-# import iris tests first so that some things can be initialised before importing anything else
+# import iris tests first, to initialise before importing anything else
 import iris.tests as tests
+
 
 class Test(tests.IrisTest):
     def test_iris_installation(self):
@@ -19,6 +19,7 @@ class Test(tests.IrisTest):
         # Import a ugrid-specific test, that ought to exist on the branch.
         from iris.tests.unit.fileformats.cf.test_CFReader import Test_exclude_vars
         self.assertTrue(hasattr(Test_exclude_vars, 'test_exclude_vars'))
+
 
 if __name__ == "__main__":
     tests.main()

--- a/iris_ugrid/tests/test_install.py
+++ b/iris_ugrid/tests/test_install.py
@@ -17,7 +17,8 @@ class Test(tests.IrisTest):
     def test_iris_installation(self):
         # Check that iris cf loader includes 'exclude' functionality.
         # Import a ugrid-specific test, that ought to exist on the branch.
-        from iris.tests.unit.fileformats.cf.test_CFReader import Test_exclude_vars
+        from iris.tests.unit.fileformats.cf.test_CFReader \
+            import Test_exclude_vars
         self.assertTrue(hasattr(Test_exclude_vars, 'test_exclude_vars'))
 
 

--- a/iris_ugrid/tests/test_install.py
+++ b/iris_ugrid/tests/test_install.py
@@ -1,0 +1,24 @@
+# Copyright Iris-ugrid contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Test that the correct iris is installed, including iris-ugrid support.
+
+TODO: remove this when we have other more sensible tests.
+
+"""
+
+# import iris tests first so that some things can be initialised before importing anything else
+import iris.tests as tests
+
+class Test(tests.IrisTest):
+    def test_iris_installation(self):
+        # Check that iris cf loader includes 'exclude' functionality.
+        # Import a ugrid-specific test, that ought to exist on the branch.
+        from iris.tests.unit.fileformats.cf.test_CFReader import Test_exclude_vars
+        self.assertTrue(hasattr(Test_exclude_vars, 'test_exclude_vars'))
+
+if __name__ == "__main__":
+    tests.main()


### PR DESCRIPTION
This ought to address #7 and  #6, but #7 is rather broad.
It probably is good enough for #6, but intentions need agreeing with @trexfeathers, who will not be available until next week.

I think this is a workable starting point for CI testing.
It introduces a dummy testfile, `iris_ugrid/tests/test_install.py` that can subsequently be removed.