### PR TITLE
Use pytest for testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,4 +90,4 @@ install:
 
 script:
 
-  - python -m unittest discover -v ./iris_ugrid/tests
+  - pytest -v ./iris_ugrid/tests

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,1 +1,2 @@
 gridded
+pytest

--- a/iris_ugrid/tests/test_install.py
+++ b/iris_ugrid/tests/test_install.py
@@ -17,7 +17,3 @@ def test_iris_installation():
         import Test_exclude_vars
 
     assert hasattr(Test_exclude_vars, 'test_exclude_vars')
-
-
-def test_failure():
-    assert False

--- a/iris_ugrid/tests/test_install.py
+++ b/iris_ugrid/tests/test_install.py
@@ -10,6 +10,7 @@ TODO: remove this when we have other more sensible tests.
 
 """
 
+
 def test_iris_installation():
     # Check that iris cf loader includes 'exclude' functionality.
     # Import a ugrid-specific test, that ought to exist on the branch.

--- a/iris_ugrid/tests/test_install.py
+++ b/iris_ugrid/tests/test_install.py
@@ -9,18 +9,15 @@ Test that the correct iris is installed, including iris-ugrid support.
 TODO: remove this when we have other more sensible tests.
 
 """
-# import iris tests first, to initialise before importing anything else
-import iris.tests as tests
+
+def test_iris_installation():
+    # Check that iris cf loader includes 'exclude' functionality.
+    # Import a ugrid-specific test, that ought to exist on the branch.
+    from iris.tests.unit.fileformats.cf.test_CFReader \
+        import Test_exclude_vars
+
+    assert hasattr(Test_exclude_vars, 'test_exclude_vars')
 
 
-class Test(tests.IrisTest):
-    def test_iris_installation(self):
-        # Check that iris cf loader includes 'exclude' functionality.
-        # Import a ugrid-specific test, that ought to exist on the branch.
-        from iris.tests.unit.fileformats.cf.test_CFReader \
-            import Test_exclude_vars
-        self.assertTrue(hasattr(Test_exclude_vars, 'test_exclude_vars'))
-
-
-if __name__ == "__main__":
-    tests.main()
+def test_failure():
+    assert False


### PR DESCRIPTION
Assuming that we are happy to reply on pytest from now on, this allows us to adopt pytest-style testing generally.
So I simplified the placeholder `tests/test_install.py` to show that.

Already checked separately, in own repo, : that a pytest test fail will trigger a Travis failure :heavy_check_mark: 