### PR TITLE
Iris branch for testing is now 'ugrid'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
   # iris test-data reference is just a commit
   - export IRIS_TEST_DATA_REF="672dbb46c986038fa5d06a3d8aad691fd1951e07"
 
-  # iris reference is to the latest "ng-vat_v2" branch
-  - export IRIS_BRANCH="ng-vat_v2"
+  # iris reference is to the latest "ugrid" branch
+  - export IRIS_BRANCH="ugrid"
 
   # download and install iris test data
   - >


### PR DESCRIPTION
I have created the Iris "ugrid" branch, so far identical to "ng-vat_v2"
We can retire "ng-vat_v2" in due course.
I have also re-targetted https://github.com/SciTools/iris/pull/3778 to the new branch.