### PR TITLE
Full markdown format for the README badge(s).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
-<p align="center">
-<!-- https://shields.io/ is a good source of these -->
-<a href="https://github.com/psf/black">
-<img src="https://img.shields.io/badge/code%20style-black-000000.svg"
-     alt="black" /></a>
-</p>
+[comment]: # (https://shields.io/ is a good source of these)
+[![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 # iris-ugrid
 Unstructured mesh library for Iris


### PR DESCRIPTION
I have reformatted the badge code in the README to use markdown format.

This sacrifices some rich formatting available using HTML format (e.g. [Iris' README](https://github.com/SciTools/iris/blob/master/README.md)) - I know we can't have centralised text for instance - but is more consistent with the markdown philosophy.