### PR TITLE
Ucubes and their summaries

### DIFF
--- a/iris_ugrid/tests/integration/test_ugrid_load.py
+++ b/iris_ugrid/tests/integration/test_ugrid_load.py
@@ -16,7 +16,9 @@ import iris.tests as tests
 from gridded.pyugrid.ugrid import UGrid
 
 from iris import Constraint
-from iris.cube import CubeList
+from iris.cube import CubeList, Cube
+
+from iris_ugrid.ucube import UCube
 from iris_ugrid.ugrid_cf_reader import CubeUgrid, load_cubes
 
 
@@ -38,9 +40,9 @@ class TestUgrid(tests.IrisTest):
         self.assertEqual(len(loaded_cubes), 2)
 
         (cube_0,) = loaded_cubes.extract(Constraint("theta"))
-        (cube_1,) = loaded_cubes.extract(Constraint("radius"))
 
         # Check the primary cube.
+        self.assertIsInstance(cube_0, UCube)
         self.assertEqual(cube_0.var_name, "theta")
         self.assertEqual(cube_0.long_name, "Potential Temperature")
         self.assertEqual(cube_0.shape, (1, 6, 866))
@@ -62,6 +64,16 @@ class TestUgrid(tests.IrisTest):
         ugrid = cubegrid.grid
         self.assertIsInstance(ugrid, UGrid)
         self.assertEqual(ugrid.mesh_name, "Mesh0")
+
+    def test_nonugrid_load(self):
+        # Check that ugrid-load can still return "ordinary" cubes.
+        file_path = tests.get_data_path(
+            ("NetCDF", "rotated", "xy", "rotPole_landAreaFraction.nc")
+        )
+        cubes = CubeList(load_cubes(file_path))
+        cube = cubes[0]
+        self.assertIsInstance(cube, Cube)
+        self.assertFalse(isinstance(cube, UCube))
 
 
 if __name__ == "__main__":

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -48,14 +48,9 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
           time                           x          -        -
      Unstructured mesh:
           Mesh0.node                     -          -        x
-              Cube unstructured-grid dimension:
-                 cube dimension = 2
-                 mesh_location = "node"
-                 mesh "Mesh0" :
-                 topology_dimension "2" :
-                 node_coordinates "latitude longitude" :
-                   <unprintable mesh>
-              
+              topology_dimension "2" :
+              node_coordinates "latitude longitude" :
+              <unprintable mesh>
      Attributes:
           Conventions: UGRID
           timeStamp: 2016-Oct-24 15:16:48 BST

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -6,8 +6,9 @@
 """
 Test basic :class:`iris_ugrid.ucube.Ucube` object.
 """
-
 import iris.tests as tests
+
+import re
 
 from iris import Constraint
 from iris.tests import IrisTest, get_data_path
@@ -25,19 +26,25 @@ class Test_cube_representations(IrisTest):
         loaded_cubes = CubeList(load_cubes(file_path))
         (cube,) = loaded_cubes.extract(Constraint("theta"))
         # Prune the attributes, just because there are a lot.
-        keep_attrs = ['timeStamp', 'Conventions']
-        cube.attributes = {key: value
-                           for key, value in cube.attributes.items()
-                           if key in keep_attrs}
+        keep_attrs = ["timeStamp", "Conventions"]
+        cube.attributes = {
+            key: value
+            for key, value in cube.attributes.items()
+            if key in keep_attrs
+        }
         self.ucube = cube
 
-    def test_cube_summary_short(self):
+    def test_summary_short(self):
+        # Check the short-form of a UCube summary.
+        # This the same as what will appear in a CubeList string repr.
         result = self.ucube.summary(shorten=True)
-        expected = ('Potential Temperature / (K)         '
-                    '(time: 1; levels: 6; *-- : 866)')
+        expected = (
+            "Potential Temperature / (K)         "
+            "(time: 1; levels: 6; *-- : 866)"
+        )
         self.assertEqual(result, expected)
 
-    def test_cube_summary_long(self):
+    def test_summary_long(self):
         result = str(self.ucube)
         expected = """\
 Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
@@ -58,6 +65,20 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
           point: time\
 """
         self.assertEqual(result, expected)
+
+    def test__repr_html_(self):
+        result = self.ucube._repr_html_()
+        # Check for some key pieces of html, which indicate that it includes
+        # a summary of the unstructured dimension, and mesh details.
+        str_dim = '<th class="iris iris-word-cell">*--</th>'
+        self.assertIn(str_dim, result)
+        str_section = \
+            '<td class="iris-title iris-word-cell">Unstructured mesh</td>'
+        self.assertIn(str_section, result)
+        re_mesh = (r'<td class="iris-word-cell iris-subheading-cell">'
+                   r'\s*Mesh0\s*</td>'
+                   r'\s*<td class="iris-inclusion-cell">node</td>')
+        self.assertIsNotNone(re.search(re_mesh, result))
 
 
 if __name__ == "__main__":

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -1,0 +1,69 @@
+# Copyright Iris-ugrid contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Test basic :class:`iris_ugrid.ucube.Ucube` object.
+"""
+
+import iris.tests as tests
+
+from iris import Constraint
+from iris.tests import IrisTest, get_data_path
+
+from iris.cube import CubeList
+
+from iris_ugrid.ugrid_cf_reader import load_cubes
+
+
+class Test_cube_representations(IrisTest):
+    def setUp(self):
+        file_path = get_data_path(
+            ("NetCDF", "unstructured_grid", "theta_nodal_xios.nc")
+        )
+        loaded_cubes = CubeList(load_cubes(file_path))
+        (cube,) = loaded_cubes.extract(Constraint("theta"))
+        # Prune the attributes, just because there are a lot.
+        keep_attrs = ['timeStamp', 'Conventions']
+        cube.attributes = {key: value
+                           for key, value in cube.attributes.items()
+                           if key in keep_attrs}
+        self.ucube = cube
+
+    def test_cube_summary_short(self):
+        result = self.ucube.summary(shorten=True)
+        expected = ('Potential Temperature / (K)         '
+                    '(time: 1; levels: 6; *-- : 866)')
+        self.assertEqual(result, expected)
+
+    def test_cube_summary_long(self):
+        result = str(self.ucube)
+        expected = """\
+Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
+     Dimension coordinates:
+          time                           x          -        -
+          levels                         -          x        -
+     Auxiliary coordinates:
+          time                           x          -        -
+     Unstructured mesh:
+          Mesh0.node                     -          -        x
+              Cube unstructured-grid dimension:
+                 cube dimension = 2
+                 mesh_location = "node"
+                 mesh "Mesh0" :
+                 topology_dimension "2" :
+                 node_coordinates "latitude longitude" :
+                   <unprintable mesh>
+              
+     Attributes:
+          Conventions: UGRID
+          timeStamp: 2016-Oct-24 15:16:48 BST
+     Cell methods:
+          point: time\
+"""
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -58,15 +58,23 @@ class UCube(Cube):
         if self.ugrid and not shorten:
             # Get a mesh description : as it prints itself.
             detail_lines = str(self.ugrid).split("\n")
+            # Use only certain parts: which happens to be the last N lines.
+            i_wanted_line, = [i
+                              for i, line in enumerate(detail_lines)
+                              if 'topology_dimension' in line]
+            # Cut out end portion, strip lines and discard blank ones.
+            detail_lines = detail_lines[i_wanted_line:]
+            detail_lines = [line.strip() for line in detail_lines]
+            detail_lines = [line for line in detail_lines if line]
 
             # Find the section that shows the grid info.
             summary_lines = summary.split("\n")
             ugrid_section_title = "Unstructured mesh"
-            i_ugrid_line = [
+            i_ugrid_line, = [
                 i
                 for i, line in enumerate(summary_lines)
                 if line.strip().startswith(ugrid_section_title)
-            ][0]
+            ]
 
             # Get the indent of the line below (the grid variable dims).
             next_line = summary_lines[i_ugrid_line + 1]

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -1,0 +1,17 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Defines the UCube : a cube which has an unstructured mesh dimension.
+
+"""
+from iris.cube import Cube
+
+
+class UCube(Cube):
+    # Derived 'unstructured' Cube subtype, with a '.ugrid' property.
+    def __init__(self, *args, ugrid=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ugrid = ugrid

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -93,5 +93,3 @@ class UCube(Cube):
             summary = "\n".join(summary_lines)
 
         return summary
-
-

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -260,6 +260,7 @@ class UGridCFReader(CFReader):
 
         return new_result_cube
 
+
 def load_cubes(filenames, callback=None):
     """
     Load cubes from a netcdf file, interpreting both UGRID and CF structure.

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -100,6 +100,18 @@ class CubeUgrid(
 
     def name(self):
         return ".".join([self.grid.mesh_name, self.mesh_location])
+ 
+    def cube_dims(self, cube):
+        # This is needed for cube summary generation, because this object is
+        # included as a "cube element" in the list structure returned by
+        # :meth:`UCube._summary_vector_sections_info`.
+        # All the other elements are _DimensionalMetadata objects.
+        # Hopefully this will be the only aspect of those which we must mimic.
+        if self.cube_dim is None:
+            result = ()
+        else:
+            result = (self.cube_dim,)
+        return result
 
 
 class UGridCFReader(CFReader):


### PR DESCRIPTION
**WIP**

This is a heads-up for the intended changes to make unstructured cubes load as `UCube`s (i.e. a specialised subclass), 
and then to make them print augmented cube summaries.
Along with https://github.com/SciTools/iris/pull/3914, this effectively completes the import of https://github.com/SciTools/iris/pull/3688 ,which was the POC code for this in the irtis "ng-vat" branch.

Unfinished business:
  - [ ] requires https://github.com/SciTools/iris/pull/3914 .  May need change if that changes.
  - [x] needs some kind of testing for `UCube._repr_html_` 
  - [x] ~ideally, should test that loading can (correctly) produce a **_mixture_** of UCube-s and Cube-s.~
        ( second thoughts : not very important. not going to bother )
