### PR TITLE
UCube summary improvements

### DIFF
--- a/iris_ugrid/tests/integration/test_ugrid_load.py
+++ b/iris_ugrid/tests/integration/test_ugrid_load.py
@@ -16,7 +16,9 @@ import iris.tests as tests
 from gridded.pyugrid.ugrid import UGrid
 
 from iris import Constraint
-from iris.cube import CubeList
+from iris.cube import CubeList, Cube
+
+from iris_ugrid.ucube import UCube
 from iris_ugrid.ugrid_cf_reader import CubeUgrid, load_cubes
 
 
@@ -38,9 +40,9 @@ class TestUgrid(tests.IrisTest):
         self.assertEqual(len(loaded_cubes), 2)
 
         (cube_0,) = loaded_cubes.extract(Constraint("theta"))
-        (cube_1,) = loaded_cubes.extract(Constraint("radius"))
 
         # Check the primary cube.
+        self.assertIsInstance(cube_0, UCube)
         self.assertEqual(cube_0.var_name, "theta")
         self.assertEqual(cube_0.long_name, "Potential Temperature")
         self.assertEqual(cube_0.shape, (1, 6, 866))
@@ -62,6 +64,16 @@ class TestUgrid(tests.IrisTest):
         ugrid = cubegrid.grid
         self.assertIsInstance(ugrid, UGrid)
         self.assertEqual(ugrid.mesh_name, "Mesh0")
+
+    def test_nonugrid_load(self):
+        # Check that ugrid-load can still return "ordinary" cubes.
+        file_path = tests.get_data_path(
+            ("NetCDF", "rotated", "xy", "rotPole_landAreaFraction.nc")
+        )
+        cubes = CubeList(load_cubes(file_path))
+        cube = cubes[0]
+        self.assertIsInstance(cube, Cube)
+        self.assertFalse(isinstance(cube, UCube))
 
 
 if __name__ == "__main__":

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -48,14 +48,9 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
           time                           x          -        -
      Unstructured mesh:
           Mesh0.node                     -          -        x
-              Cube unstructured-grid dimension:
-                 cube dimension = 2
-                 mesh_location = "node"
-                 mesh "Mesh0" :
-                 topology_dimension "2" :
-                 node_coordinates "latitude longitude" :
-                   <unprintable mesh>
-              
+              topology_dimension "2" :
+              node_coordinates "latitude longitude" :
+              <unprintable mesh>
      Attributes:
           Conventions: UGRID
           timeStamp: 2016-Oct-24 15:16:48 BST

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -55,9 +55,10 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
           time                           x          -        -
      Unstructured mesh:
           Mesh0.node                     -          -        x
-              topology_dimension "2" :
-              node_coordinates "latitude longitude" :
-              <unprintable mesh>
+               topology_dimension: "2"
+               node_coordinates: "latitude longitude"
+               mesh detail:
+                    <unprintable mesh>
      Attributes:
           Conventions: UGRID
           timeStamp: 2016-Oct-24 15:16:48 BST

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -6,8 +6,9 @@
 """
 Test basic :class:`iris_ugrid.ucube.Ucube` object.
 """
-
 import iris.tests as tests
+
+import re
 
 from iris import Constraint
 from iris.tests import IrisTest, get_data_path
@@ -25,19 +26,25 @@ class Test_cube_representations(IrisTest):
         loaded_cubes = CubeList(load_cubes(file_path))
         (cube,) = loaded_cubes.extract(Constraint("theta"))
         # Prune the attributes, just because there are a lot.
-        keep_attrs = ['timeStamp', 'Conventions']
-        cube.attributes = {key: value
-                           for key, value in cube.attributes.items()
-                           if key in keep_attrs}
+        keep_attrs = ["timeStamp", "Conventions"]
+        cube.attributes = {
+            key: value
+            for key, value in cube.attributes.items()
+            if key in keep_attrs
+        }
         self.ucube = cube
 
-    def test_cube_summary_short(self):
+    def test_summary_short(self):
+        # Check the short-form of a UCube summary.
+        # This the same as what will appear in a CubeList string repr.
         result = self.ucube.summary(shorten=True)
-        expected = ('Potential Temperature / (K)         '
-                    '(time: 1; levels: 6; *-- : 866)')
+        expected = (
+            "Potential Temperature / (K)         "
+            "(time: 1; levels: 6; *-- : 866)"
+        )
         self.assertEqual(result, expected)
 
-    def test_cube_summary_long(self):
+    def test_summary_long(self):
         result = str(self.ucube)
         expected = """\
 Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
@@ -58,6 +65,20 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
           point: time\
 """
         self.assertEqual(result, expected)
+
+    def test__repr_html_(self):
+        result = self.ucube._repr_html_()
+        # Check for some key pieces of html, which indicate that it includes
+        # a summary of the unstructured dimension, and mesh details.
+        str_dim = '<th class="iris iris-word-cell">*--</th>'
+        self.assertIn(str_dim, result)
+        str_section = \
+            '<td class="iris-title iris-word-cell">Unstructured mesh</td>'
+        self.assertIn(str_section, result)
+        re_mesh = (r'<td class="iris-word-cell iris-subheading-cell">'
+                   r'\s*Mesh0\s*</td>'
+                   r'\s*<td class="iris-inclusion-cell">node</td>')
+        self.assertIsNotNone(re.search(re_mesh, result))
 
 
 if __name__ == "__main__":

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -1,0 +1,69 @@
+# Copyright Iris-ugrid contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Test basic :class:`iris_ugrid.ucube.Ucube` object.
+"""
+
+import iris.tests as tests
+
+from iris import Constraint
+from iris.tests import IrisTest, get_data_path
+
+from iris.cube import CubeList
+
+from iris_ugrid.ugrid_cf_reader import load_cubes
+
+
+class Test_cube_representations(IrisTest):
+    def setUp(self):
+        file_path = get_data_path(
+            ("NetCDF", "unstructured_grid", "theta_nodal_xios.nc")
+        )
+        loaded_cubes = CubeList(load_cubes(file_path))
+        (cube,) = loaded_cubes.extract(Constraint("theta"))
+        # Prune the attributes, just because there are a lot.
+        keep_attrs = ['timeStamp', 'Conventions']
+        cube.attributes = {key: value
+                           for key, value in cube.attributes.items()
+                           if key in keep_attrs}
+        self.ucube = cube
+
+    def test_cube_summary_short(self):
+        result = self.ucube.summary(shorten=True)
+        expected = ('Potential Temperature / (K)         '
+                    '(time: 1; levels: 6; *-- : 866)')
+        self.assertEqual(result, expected)
+
+    def test_cube_summary_long(self):
+        result = str(self.ucube)
+        expected = """\
+Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
+     Dimension coordinates:
+          time                           x          -        -
+          levels                         -          x        -
+     Auxiliary coordinates:
+          time                           x          -        -
+     Unstructured mesh:
+          Mesh0.node                     -          -        x
+              Cube unstructured-grid dimension:
+                 cube dimension = 2
+                 mesh_location = "node"
+                 mesh "Mesh0" :
+                 topology_dimension "2" :
+                 node_coordinates "latitude longitude" :
+                   <unprintable mesh>
+              
+     Attributes:
+          Conventions: UGRID
+          timeStamp: 2016-Oct-24 15:16:48 BST
+     Cell methods:
+          point: time\
+"""
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    tests.main()

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -57,7 +57,7 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
           Mesh0.node                     -          -        x
                topology_dimension: "2"
                node_coordinates: "latitude longitude"
-               mesh detail:
+               Mesh detail:
                     <unprintable mesh>
      Attributes:
           Conventions: UGRID

--- a/iris_ugrid/tests/unit/ucube/test_UCube.py
+++ b/iris_ugrid/tests/unit/ucube/test_UCube.py
@@ -72,12 +72,15 @@ Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
         # a summary of the unstructured dimension, and mesh details.
         str_dim = '<th class="iris iris-word-cell">*--</th>'
         self.assertIn(str_dim, result)
-        str_section = \
+        str_section = (
             '<td class="iris-title iris-word-cell">Unstructured mesh</td>'
+        )
         self.assertIn(str_section, result)
-        re_mesh = (r'<td class="iris-word-cell iris-subheading-cell">'
-                   r'\s*Mesh0\s*</td>'
-                   r'\s*<td class="iris-inclusion-cell">node</td>')
+        re_mesh = (
+            r'<td class="iris-word-cell iris-subheading-cell">'
+            r"\s*Mesh0\s*</td>"
+            r'\s*<td class="iris-inclusion-cell">node</td>'
+        )
         self.assertIsNotNone(re.search(re_mesh, result))
 
 

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -58,15 +58,23 @@ class UCube(Cube):
         if self.ugrid and not shorten:
             # Get a mesh description : as it prints itself.
             detail_lines = str(self.ugrid).split("\n")
+            # Use only certain parts: which happens to be the last N lines.
+            i_wanted_line, = [i
+                              for i, line in enumerate(detail_lines)
+                              if 'topology_dimension' in line]
+            # Cut out end portion, strip lines and discard blank ones.
+            detail_lines = detail_lines[i_wanted_line:]
+            detail_lines = [line.strip() for line in detail_lines]
+            detail_lines = [line for line in detail_lines if line]
 
             # Find the section that shows the grid info.
             summary_lines = summary.split("\n")
             ugrid_section_title = "Unstructured mesh"
-            i_ugrid_line = [
+            i_ugrid_line, = [
                 i
                 for i, line in enumerate(summary_lines)
                 if line.strip().startswith(ugrid_section_title)
-            ][0]
+            ]
 
             # Get the indent of the line below (the grid variable dims).
             next_line = summary_lines[i_ugrid_line + 1]

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -66,7 +66,7 @@ class UCube(Cube):
             ]
             # Cut out end portion, strip lines and discard blank ones.
             detail_lines = detail_lines[i_wanted_line:]
-            detail_lines = [line.strip() for line in detail_lines]
+            # detail_lines = [line.strip() for line in detail_lines]
             detail_lines = [line for line in detail_lines if line]
 
             # Find the section that shows the grid info.
@@ -85,7 +85,7 @@ class UCube(Cube):
             ][0]
 
             # Indent the mesh details 4 spaces more than that.
-            indent_string = " " * (indent_number + 4)
+            indent_string = " " * (indent_number)
             detail_lines = [indent_string + line for line in detail_lines]
 
             # Splice in the detail lines after that, indenting to match.

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -24,7 +24,7 @@ class UCube(Cube):
 
         """
         name = super()._summary_dim_name(dim)
-        if self.ugrid and dim == self.ugrid.cube_dim:
+        if self.ugrid is not None and dim == self.ugrid.cube_dim:
             name = "*" + name
         return name
 

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -59,9 +59,11 @@ class UCube(Cube):
             # Get a mesh description : as it prints itself.
             detail_lines = str(self.ugrid).split("\n")
             # Use only certain parts: which happens to be the last N lines.
-            i_wanted_line, = [i
-                              for i, line in enumerate(detail_lines)
-                              if 'topology_dimension' in line]
+            (i_wanted_line,) = [
+                i
+                for i, line in enumerate(detail_lines)
+                if "topology_dimension" in line
+            ]
             # Cut out end portion, strip lines and discard blank ones.
             detail_lines = detail_lines[i_wanted_line:]
             detail_lines = [line.strip() for line in detail_lines]
@@ -70,7 +72,7 @@ class UCube(Cube):
             # Find the section that shows the grid info.
             summary_lines = summary.split("\n")
             ugrid_section_title = "Unstructured mesh"
-            i_ugrid_line, = [
+            (i_ugrid_line,) = [
                 i
                 for i, line in enumerate(summary_lines)
                 if line.strip().startswith(ugrid_section_title)

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -1,0 +1,17 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""
+Defines the UCube : a cube which has an unstructured mesh dimension.
+
+"""
+from iris.cube import Cube
+
+
+class UCube(Cube):
+    # Derived 'unstructured' Cube subtype, with a '.ugrid' property.
+    def __init__(self, *args, ugrid=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ugrid = ugrid

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -93,5 +93,3 @@ class UCube(Cube):
             summary = "\n".join(summary_lines)
 
         return summary
-
-

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -80,13 +80,13 @@ class UCube(Cube):
 
             # Get the indent of the line below (the grid variable dims).
             next_line = summary_lines[i_ugrid_line + 1]
-            indent = [
+            indent_number = [
                 ind for ind, char in enumerate(next_line) if char != " "
             ][0]
 
             # Indent the mesh details 4 spaces more than that.
-            indent = " " * (indent + 4)
-            detail_lines = [indent + line for line in detail_lines]
+            indent_string = " " * (indent_number + 4)
+            detail_lines = [indent_string + line for line in detail_lines]
 
             # Splice in the detail lines after that, indenting to match.
             i_next_section = i_ugrid_line + 2

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -66,7 +66,6 @@ class UCube(Cube):
             ]
             # Cut out end portion, strip lines and discard blank ones.
             detail_lines = detail_lines[i_wanted_line:]
-            # detail_lines = [line.strip() for line in detail_lines]
             detail_lines = [line for line in detail_lines if line]
 
             # Find the section that shows the grid info.

--- a/iris_ugrid/ucube.py
+++ b/iris_ugrid/ucube.py
@@ -84,7 +84,8 @@ class UCube(Cube):
                 ind for ind, char in enumerate(next_line) if char != " "
             ][0]
 
-            # Indent the mesh details 4 spaces more than that.
+            # Indent the mesh details to the same level (they have the their
+            # own inherent extra indent).
             indent_string = " " * (indent_number)
             detail_lines = [indent_string + line for line in detail_lines]
 

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -201,6 +201,14 @@ class UGridCFReader(CFReader):
         Constructs a :class:`CubeUgrid` referencing the appropriate file mesh,
         and makes a new `UCube` of which this is the '.ugrid' property.
 
+        Args:
+
+        * cube (:class:`iris.cube.Cube`):
+            The cube to be post-processed
+
+        Returns:
+            :class:`iris_ugrid.ucube.UCube`
+
         """
         # Identify the unstructured-grid dimension of the cube (if any), and
         # attach a suitable CubeUgrid object
@@ -238,8 +246,9 @@ class UGridCFReader(CFReader):
                 topology_dimension=topology_dimension,
                 node_coordinates=sorted(node_coordinates),
             )
-            # Return a new UCube, based on the provided Cube, and replacing it
-            # in the caller (and as returned to user).
+            # Return a new UCube, based on the provided Cube. Relying on the
+            # caller (e.g. :func:iris.fileformats.netcdf.load_cubes) to
+            # appropriately handle any replacement of the original Cube.
             # Absolutely **everything** is the same, except for the extra ugrid
             # property.
             new_result_cube = UCube(

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -80,21 +80,23 @@ class CubeUgrid(
     """
 
     def __str__(self):
+        indent = " " * 5
         result = "Cube unstructured-grid dimension:"
-        result += "\n   cube dimension = {}".format(self.cube_dim)
-        result += '\n   mesh_location = "{}"'.format(self.mesh_location)
-        result += '\n   mesh "{}" :'.format(self.grid.mesh_name)
-        result += '\n   topology_dimension "{}" :'.format(
-            self.topology_dimension
+        result += f"\n{indent}cube dimension = {self.cube_dim}"
+        result += f'\n{indent}mesh_location = "{self.mesh_location}"'
+        result += f'\n{indent}mesh: "{self.grid.mesh_name}"'
+        result += f'\n{indent}topology_dimension: "{self.topology_dimension}"'
+        result += (
+            f'\n{indent}node_coordinates: "{" ".join(self.node_coordinates)}"'
         )
-        result += '\n   node_coordinates "{}" :\n'.format(
-            " ".join(self.node_coordinates)
-        )
+        result += f"\n{indent}mesh detail:\n"
         try:
             mesh_str = str(self.grid.info)
         except TypeError:
             mesh_str = "<unprintable mesh>"
-        result += "\n".join(["     " + line for line in mesh_str.split("\n")])
+        result += "\n".join(
+            [(indent * 2) + line for line in mesh_str.split("\n")]
+        )
         result += "\n"
         return result
 

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -89,7 +89,7 @@ class CubeUgrid(
         result += (
             f'\n{indent}node_coordinates: "{" ".join(self.node_coordinates)}"'
         )
-        result += f"\n{indent}mesh detail:\n"
+        result += f"\n{indent}Mesh detail:\n"
         try:
             mesh_str = str(self.grid.info)
         except TypeError:

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -100,7 +100,7 @@ class CubeUgrid(
 
     def name(self):
         return ".".join([self.grid.mesh_name, self.mesh_location])
- 
+
     def cube_dims(self, cube):
         # This is needed for cube summary generation, because this object is
         # included as a "cube element" in the list structure returned by

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -260,6 +260,7 @@ class UGridCFReader(CFReader):
 
         return new_result_cube
 
+
 def load_cubes(filenames, callback=None):
     """
     Load cubes from a netcdf file, interpreting both UGRID and CF structure.

--- a/iris_ugrid/ugrid_cf_reader.py
+++ b/iris_ugrid/ugrid_cf_reader.py
@@ -100,6 +100,18 @@ class CubeUgrid(
 
     def name(self):
         return ".".join([self.grid.mesh_name, self.mesh_location])
+ 
+    def cube_dims(self, cube):
+        # This is needed for cube summary generation, because this object is
+        # included as a "cube element" in the list structure returned by
+        # :meth:`UCube._summary_vector_sections_info`.
+        # All the other elements are _DimensionalMetadata objects.
+        # Hopefully this will be the only aspect of those which we must mimic.
+        if self.cube_dim is None:
+            result = ()
+        else:
+            result = (self.cube_dim,)
+        return result
 
 
 class UGridCFReader(CFReader):


### PR DESCRIPTION
**Needs #27 first - setting as draft until then**

This PR proposes some minor changes to the string representation of `CubeUgrid`, and how this is handled downstream by `UCube.summary()`.

#### Examples from real files

<details><summary>1</summary>

```
m_v / (kg/kg)                       (-- : 1; full_levels: 39; *-- : 864)
     Dimension coordinates:
          full_levels                   -               x         -
     Auxiliary coordinates:
          time                          x               -         -
     Unstructured mesh:
          Mesh2d_full_levels.face       -               -         x
               topology_dimension: "2"
               node_coordinates: "latitude longitude"
               mesh detail:
                    UGrid object:
                    Number of nodes: 866
                    Number of faces: 864 with 4 vertices per face
     Attributes:
          Conventions: UGRID
          description: Created by xios
          interval_operation: 1800 s
          interval_write: 3600 s
          location: face
          mesh: Mesh2d_full_levels
          name: lfric_diag
          online_operation: instant
          timeStamp: 2019-Jul-08 14:38:47 GMT
          title: Created by xios
          uuid: 6dd6878b-eb6a-49c5-b3a1-5c8b3e94447f
     Cell methods:
          point: time (1800 s)
```
</details>

<details><summary>2</summary>

```
Potential Temperature / (K)         (time: 1; levels: 6; *-- : 866)
     Dimension coordinates:
          time                           x          -        -
          levels                         -          x        -
     Auxiliary coordinates:
          time                           x          -        -
     Unstructured mesh:
          Mesh0.node                     -          -        x
               topology_dimension: "2"
               node_coordinates: "latitude longitude"
               mesh detail:
                    <unprintable mesh>
     Attributes:
          Conventions: UGRID
          timeStamp: 2016-Oct-24 15:16:48 BST
     Cell methods:
          point: time
```
</details>