### PR TITLE
Swap the docstrings for __init__.py and tests.__init__.py

### DIFF
--- a/iris_ugrid/__init__.py
+++ b/iris_ugrid/__init__.py
@@ -3,6 +3,6 @@
 # This file is part of Iris and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
-"""All tests for the :mod:`iris-ugrid` package."""
+"""Top level of iris-ugrid package."""
 
 __version__ = "0.1.0regrid1"

--- a/iris_ugrid/tests/__init__.py
+++ b/iris_ugrid/tests/__init__.py
@@ -3,4 +3,4 @@
 # This file is part of Iris and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
-"""Top level of iris-ugrid package."""
+"""All tests for the :mod:`iris-ugrid` package."""


### PR DESCRIPTION
The docstrings for __init__.py and tests.__init__.py were the wrong way around.