### PR TITLE
Include synthetic_data_generator/mesh_headers directory when installing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,10 @@ python_requires =
 setup_requires =
     setuptools>=40.8.0
 zip_safe = False
+include_package_data = True
+
+[options.package_data]
+* = tests/synthetic_data_generator/mesh_headers/*.txt
 
 [tool:pytest]
 testpaths =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ zip_safe = False
 include_package_data = True
 
 [options.package_data]
-* = tests/synthetic_data_generator/mesh_headers/*.txt
+* = tests/synthetic_data_generator/mesh_headers/*
 
 [tool:pytest]
 testpaths =


### PR DESCRIPTION
The contents of [`iris_ugrid/tests/synthetic_data_generator/mesh_headers`](https://github.com/SciTools-incubator/iris-ugrid/tree/master/iris_ugrid/tests/synthetic_data_generator/mesh_headers) are needed to support testing, but need to explicitly named in `setup.cfg` before they will be included when running `python setup.py install`.