### PR TITLE
PEP440-compliant version string

### DIFF
--- a/iris_ugrid/__init__.py
+++ b/iris_ugrid/__init__.py
@@ -5,4 +5,4 @@
 # licensing details.
 """Top level of iris-ugrid package."""
 
-__version__ = "0.1.0regrid1"
+__version__ = "0.1.dev0"


### PR DESCRIPTION
Closes #34 
Have tested with Airspeed Velocity and this change re-enables benchmarking iris-ugrid.